### PR TITLE
Only one BIC per bank account (BT-86)

### DIFF
--- a/src/xsl/cii-xr.xsl
+++ b/src/xsl/cii-xr.xsl
@@ -1175,13 +1175,17 @@
          <xsl:apply-templates mode="BT-84" select="./ram:ProprietaryID"/>
          <xsl:apply-templates mode="BT-84" select="./ram:IBANID"/>
          <xsl:apply-templates mode="BT-85" select="./ram:AccountName"/>
+		 
+		 <!-- Anpassung, dass nur eine (richtige) BIC pro Bankverbindung angezeigt wird -->
+		 <xsl:apply-templates mode="BT-86" select="./../ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID"/>
+		 <!--
          <xr:Payment_service_provider_identifier>
             <xsl:attribute name="xr:id" select="'BT-86'"/>
             <xsl:attribute name="xr:src" select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'"/>            
             <xsl:call-template name="distinct-bt-86">
                <xsl:with-param name="bic-values" select="distinct-values(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID)"/>
             </xsl:call-template>
-         </xr:Payment_service_provider_identifier>
+         </xr:Payment_service_provider_identifier>-->
       </xsl:variable>
       <xsl:if test="$bg-contents">
          <xr:CREDIT_TRANSFER>
@@ -1214,7 +1218,17 @@
          <xsl:attribute name="xr:src" select="xr:src-path(.)"/>
          <xsl:call-template name="text"/>
       </xr:Payment_account_name>
-   </xsl:template>   
+   </xsl:template>
+   
+   <!-- Anpassung, dass nur eine (richtige) BIC pro Bankverbindung angezeigt wird -->
+   <xsl:template mode="BT-86"
+                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID">
+      <xr:Payment_service_provider_identifier>
+         <xsl:attribute name="xr:id" select="'BT-86'"/>
+         <xsl:attribute name="xr:src" select="xr:src-path(.)"/>
+         <xsl:call-template name="text"/>
+      </xr:Payment_service_provider_identifier>
+   </xsl:template> 
    <xsl:template name="distinct-bt-86"     >      
       <xsl:param as="xs:string*" name="bic-values"></xsl:param>
       <xsl:for-each select="$bic-values">


### PR DESCRIPTION
In the section "Überweisung" (BG17) all BICs have been concatenated with a semicolon and were written into all BT-86s.
In our opinion, that makes no sense if one uses multiple bank accounts at different banks.
Is there a reason for using distinct-values()?


**Before:**
Kontoinhaber:	Bank 1
IBAN:	DE11 1111 1111 1111 1111 11
_BIC:	DEMO1111XXX;DEMO2222XXX;DEMO3333XXX_

Kontoinhaber:	Bank 2
IBAN:	DE22 2222 2222 2222 2222 22
_BIC:	DEMO1111XXX;DEMO2222XXX;DEMO3333XXX_

Kontoinhaber:	Bank 3
IBAN:	DE33 3333 3333 3333 3333 33
_BIC:	DEMO1111XXX;DEMO2222XXX;DEMO3333XXX_

**After adjusting cii-xr.xsl:**
Kontoinhaber:	Bank 1
IBAN:	DE11 1111 1111 1111 1111 11
_BIC:	DEMO1111XXX_

Kontoinhaber:	Bank 2
IBAN:	DE22 2222 2222 2222 2222 22
_BIC:	DEMO2222XXX_

Kontoinhaber:	Bank 3
IBAN:	DE33 3333 3333 3333 3333 33
_BIC:	DEMO3333XXX_
