### PR TITLE
normalize-space in attachment data urls

### DIFF
--- a/src/xsl/xr-pdf/lib/structure/content-templates.xsl
+++ b/src/xsl/xr-pdf/lib/structure/content-templates.xsl
@@ -390,7 +390,7 @@
     <xsl:param name="identifier"/>   
       <pdf:embedded-file>
         <xsl:attribute name="filename"><xsl:value-of select="$identifier"/></xsl:attribute>
-        <xsl:attribute name="src">data:application/pdf;base64,<xsl:value-of select="."/></xsl:attribute>
+        <xsl:attribute name="src">data:application/pdf;base64,<xsl:value-of select="normalize-space(.)"/></xsl:attribute>
       </pdf:embedded-file> 
   </xsl:template>
 


### PR DESCRIPTION
If an `AttachmentBinaryObject` base64 contains newlines the resulting data url is invalid. This PR removes all newlines and spaces from the base64.