### PR TITLE
uri encode embedded-file uri

### DIFF
--- a/src/xsl/xr-pdf/lib/structure/content-templates.xsl
+++ b/src/xsl/xr-pdf/lib/structure/content-templates.xsl
@@ -381,7 +381,7 @@
   <xsl:template match="*|@*" mode="binary">
     <xsl:param name="identifier"/>    
     <fo:basic-link>
-      <xsl:attribute name="external-destination">url(embedded-file:<xsl:value-of select="$identifier"/>)</xsl:attribute>
+      <xsl:attribute name="external-destination">url(embedded-file:<xsl:value-of select="encode-for-uri($identifier)"/>)</xsl:attribute>
       <xsl:value-of select="$identifier"/>
     </fo:basic-link>
   </xsl:template>


### PR DESCRIPTION
If an identifier contains invalid uri characters like whitespaces which are not uri encoded, the file name resolution doesn't work in fop.