### PR TITLE
Add optional digits to amount format

### DIFF
--- a/src/xsl/l10n/de.xml
+++ b/src/xsl/l10n/de.xml
@@ -234,7 +234,7 @@
   <entry key="anlagenListe">Rechnungsbegründende Unterlagen</entry>
   <entry key="date-format">[D].[M].[Y]</entry>
   <entry key="datetime-format">[D].[M].[Y] [H]:[m]:[s]</entry>
-  <entry key="amount-format">###.##0,00</entry>
+  <entry key="amount-format">###.##0,00##########</entry>
   <entry key="percentage-format">##0,00</entry>
   <entry key="at-least-two-format">###.##0,#################</entry>
   

--- a/src/xsl/l10n/en.xml
+++ b/src/xsl/l10n/en.xml
@@ -232,7 +232,7 @@
   <entry key="anlagenListe">Documents justifying the invoice</entry>
   <entry key="date-format">[Y]-[M,2]-[D,2]</entry>
   <entry key="datetime-format">[Y]-[M,2]-[D,2] [H]:[m]:[s]</entry>
-  <entry key="amount-format">###,##0.00</entry>
+  <entry key="amount-format">###,##0.00##########</entry>
   <entry key="percentage-format">##0.00</entry>
   <entry key="at-least-two-format">###,##0.#################</entry>
   


### PR DESCRIPTION
Various UnitCode, e.g. MLT (Millilitre) imply sub-cent amounts and sub-cent amounts are generally allowed by the en16931 and Xrechnung standards.

Currently these sub-cent are omitted, which leads to seemingly false invoices, as the product of the charge amount times the quantity no longer equals the line total amount.

This PR adds 10 optional sub-cent digits to the amount-format entry for both german and english internalization files.
