### PR TITLE
use actual fo basic link for internet-link template

### DIFF
--- a/src/xsl/xr-pdf/lib/structure/content-templates.xsl
+++ b/src/xsl/xr-pdf/lib/structure/content-templates.xsl
@@ -365,7 +365,12 @@
     <xsl:param name="title" select="." />
 
     <xsl:if test="normalize-space(.)">
-      <xsl:value-of select="."/>
+      <fo:basic-link>
+        <xsl:attribute name="external-destination">
+          <xsl:value-of select="$title" />
+        </xsl:attribute>
+        <xsl:value-of select="$title" />
+      </fo:basic-link>
     </xsl:if>
   </xsl:template>
 


### PR DESCRIPTION
Atm the internet-link template produces just text and no link. This PR uses fo:basic-link to actually produce a link in the generated pdf