### PR TITLE
Fix Translation

### DIFF
--- a/src/xsl/l10n/de.xml
+++ b/src/xsl/l10n/de.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
-  <entry key="xr:Buyer_reference" id="BT-10">Leitweg-ID</entry>
+  <entry key="xr:Buyer_reference" id="BT-10">Käuferreferenz</entry>
   <entry key="xr:Buyer_name" id="BT-44">Name</entry>
   <entry key="xr:Buyer_address_line_1" id="BT-50">Adresszeile 1</entry>
   <entry key="xr:Buyer_address_line_2" id="BT-51">Adresszeile 2</entry>


### PR DESCRIPTION
A "Leitweg-ID" is only used for public clients.
The specification at https://xeinkauf.de/app/uploads/2023/02/231-XRechnung-2023-02-03.pdf specifies that the Buyer Reference can be a "Leitweg-ID" but doesn't necessarily have to be one and can also be a "Käuferreferenz" (Buyer Referernce) of any other kind.