### PR TITLE
Prevent empty element xr:Item_price_base_quantity

### DIFF
--- a/src/xsl/cii-xr.xsl
+++ b/src/xsl/cii-xr.xsl
@@ -1942,23 +1942,25 @@
                               select="./ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount"/>
          <xsl:apply-templates mode="BT-148"
                               select="./ram:GrossPriceProductTradePrice/ram:ChargeAmount"/>
-         <xr:Item_price_base_quantity>
-            <xsl:attribute name="xr:id" select="'BT-149'"/>
-            <xsl:attribute name="xr:src" select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount|/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount'"/>
-            <xsl:choose>
-               <xsl:when test="./ram:NetPriceProductTradePrice/ram:BasisQuantity != ./ram:GrossPriceProductTradePrice/ram:BasisQuantity">
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
-                  <xsl:value-of select="';'"/>
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity"/>
-               </xsl:when>
-               <xsl:otherwise>
-                  <xsl:apply-templates mode="BT-149"
-                     select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
-               </xsl:otherwise>
-            </xsl:choose>
-         </xr:Item_price_base_quantity>         
+         <xsl:if test="count(./ram:NetPriceProductTradePrice/ram:BasisQuantity) > 0">
+            <xr:Item_price_base_quantity>
+               <xsl:attribute name="xr:id" select="'BT-149'"/>
+               <xsl:attribute name="xr:src" select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:NetPriceProductTradePrice/ram:ChargeAmount|/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge/ram:ActualAmount'"/>
+               <xsl:choose>
+                  <xsl:when test="./ram:NetPriceProductTradePrice/ram:BasisQuantity != ./ram:GrossPriceProductTradePrice/ram:BasisQuantity">
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
+                     <xsl:value-of select="';'"/>
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                     <xsl:apply-templates mode="BT-149"
+                        select="./ram:NetPriceProductTradePrice/ram:BasisQuantity"/>
+                  </xsl:otherwise>
+               </xsl:choose>
+            </xr:Item_price_base_quantity>
+         </xsl:if>
          <xsl:apply-templates mode="BT-150"
                               select="./ram:GrossPriceProductTradePrice/ram:BasisQuantity/@unitCode"/>
       </xsl:variable>


### PR DESCRIPTION
"Item price base quantity" (BT-149) is an optional property. However, the cii-xr.xsl stylesheet creates it for every "Invoice line" item (BG-25).

I am using the transformation into the intermediate format to read some values from a XRechnung and noticed that this is the only case where an empty element is created.

This is not really a bug, of course, but maybe you could consider it as a small cleanup to improve consistency. Thank you for your consideration.