### PR TITLE
Update xr-pdf.xsl

### DIFF
--- a/src/xsl/xr-pdf.xsl
+++ b/src/xsl/xr-pdf.xsl
@@ -64,7 +64,7 @@
         <x:xmpmeta xmlns:x="adobe:ns:meta/">
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
-              <dc:title><xsl:value-of select="xr:Invoice_number"/></dc:title>
+              <dc:title><rdf:Alt><rdf:li xml:lang="x-default"><xsl:value-of select="xr:Invoice_number"/></rdf:li></rdf:Alt></dc:title>
               <!--
               <dc:creator></dc:creator>
               <dc:description></dc:description>


### PR DESCRIPTION
Correcting some RDF in FO, if omitted e.g. Apache FOP will create invalid PDF/A-3 out of it as can be observed when validated with VeraPDF, see https://issues.apache.org/jira/browse/FOP-3214