### PR TITLE
HTML: Fix CSS classes of field BT-65

### DIFF
--- a/src/xsl/xrechnung-html.xsl
+++ b/src/xsl/xrechnung-html.xsl
@@ -1755,7 +1755,7 @@
           <div class="boxdaten legende">
             <xsl:value-of select="xrf:_('xr:Tax_representative_address_line_2')" />:
           </div>
-          <div data-title="BT-65" class="BT-65boxdaten wert">
+          <div data-title="BT-65" class="BT-65 boxdaten wert">
             <xsl:value-of
               select="xr:SELLER_TAX_REPRESENTATIVE_POSTAL_ADDRESS/xr:Tax_representative_address_line_2" />
           </div>


### PR DESCRIPTION
Due to a missing space between `BT-65` and `boxdaten` within the CSS classes of the `div`-element for the field `BT-65`, the element is not styled as a `boxdaten` field in the output:
![image](https://github.com/user-attachments/assets/59eaae9d-c09b-4ba5-a97e-bebb43ed2bf0)