### PR TITLE
build.xml: set FO engine correctly

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -354,7 +354,7 @@
             style="${src.dir}/xsl/xr-pdf.xsl" includes="**/*.xml">
             <classpath location="${lib.dir}/${saxon.jar}"/>
             <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-            <param name="fop.extensions" type="STRING" expression="fop"/>
+            <param name="foengine" type="STRING" expression="fop"/>
             <mapper type="glob" from="*.xml" to="*.fo"/>
         </xslt>
 
@@ -369,7 +369,7 @@
             style="${src.dir}/xsl/xr-pdf.xsl" includes="**/*.xml">
             <classpath location="${lib.dir}/${saxon.jar}"/>
             <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-            <param name="fop.extensions" type="STRING" expression="fop"/>
+            <param name="foengine" type="STRING" expression="fop"/>
             <param name="invoiceline-layout" type="STRING" expression="tabular"/>
             <mapper type="glob" from="*.xml" to="*.fo"/>
         </xslt>
@@ -385,7 +385,7 @@
             style="${src.dir}/xsl/xr-pdf.xsl" includes="**/*.xml">
             <classpath location="${lib.dir}/${saxon.jar}"/>
             <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-            <param name="fop.extensions" type="STRING" expression="fop"/>
+            <param name="foengine" type="STRING" expression="fop"/>
             <param name="invoiceline-layout" type="STRING" expression="tabular"/>
             <param name="lang" type="STRING" expression="en"/>
             <mapper type="glob" from="*.xml" to="*.fo"/>


### PR DESCRIPTION
`fop.extensions` parameter in `xr-pdf.xsl` has a boolean type and is set internally depending on the value of the `foengine` parameter. Hence, set the `foengine` parameter from `build.xml` to specify the desired FO engine.