### PR TITLE
update BT-23 in en.xml to synchronize with de.xml

### DIFF
--- a/src/xsl/l10n/en.xml
+++ b/src/xsl/l10n/en.xml
@@ -134,7 +134,7 @@
   <entry key="xr:Tender_or_lot_reference" id="BT-17">Award reference</entry>
   <entry key="xr:Receiving_advice_reference" id="BT-15">Receiving advice reference</entry>
   <entry key="xr:Despatch_advice_reference" id="BT-16">Despatch advice reference</entry>
-  <entry key="xr:Business_process_type" id="BT-23">Process identifier</entry>
+  <entry key="xr:Business_process_type_identifier" id="BT-23">Process identifier</entry>
   <entry key="xr:Specification_identifier" id="BT-24">Specification identifier</entry>
   <entry key="xr:Invoiced_object_identifier" id="BT-18">Object identifier</entry>
   <entry key="xr:Invoiced_object_identifier/@scheme_identifier" id="BT-18_scheme">Object identifier scheme</entry>


### PR DESCRIPTION
I found a bug related to the BT-23 attribute in de.xml and en.xml file which lead to the incorrect format when generating pdf file.
Fixed it in this PR


