### PR TITLE
Merge CII DepartmentName and PersonName

### DIFF
--- a/src/xsl/cii-xr.xsl
+++ b/src/xsl/cii-xr.xsl
@@ -557,8 +557,7 @@
    <xsl:template mode="BG-6"
                  match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:DefinedTradeContact">
       <xsl:variable name="bg-contents" as="item()*"><!--Der Pfad /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:DefinedTradeContact der Instanz in konkreter Syntax wird auf 3 Objekte der EN 16931 abgebildet. -->
-         <xsl:apply-templates mode="BT-41" select="./ram:DepartmentName"/>
-         <xsl:apply-templates mode="BT-41" select="./ram:PersonName"/>
+         <xsl:apply-templates mode="BT-41" select="."/>
          <xsl:apply-templates mode="BT-42"
                               select="./ram:TelephoneUniversalCommunication/ram:CompleteNumber"/>
          <xsl:apply-templates mode="BT-43" select="./ram:EmailURIUniversalCommunication/ram:URIID"/>
@@ -572,19 +571,23 @@
       </xsl:if>
    </xsl:template>
    <xsl:template mode="BT-41"
-                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:DefinedTradeContact/ram:DepartmentName">
+                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:DefinedTradeContact">
       <xr:Seller_contact_point>
          <xsl:attribute name="xr:id" select="'BT-41'"/>
          <xsl:attribute name="xr:src" select="xr:src-path(.)"/>
-         <xsl:call-template name="text"/>
-      </xr:Seller_contact_point>
-   </xsl:template>
-   <xsl:template mode="BT-41"
-                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:DefinedTradeContact/ram:PersonName">
-      <xr:Seller_contact_point>
-         <xsl:attribute name="xr:id" select="'BT-41'"/>
-         <xsl:attribute name="xr:src" select="xr:src-path(.)"/>
-         <xsl:call-template name="text"/>
+         <xsl:variable name="department" select="ram:DepartmentName"/>
+         <xsl:variable name="person" select="ram:PersonName"/>
+         <xsl:choose>
+            <xsl:when test="$person and $department">
+               <xsl:value-of select="concat($person, ' (', $department, ')')"/>
+            </xsl:when>
+            <xsl:when test="$person">
+               <xsl:value-of select="$person"/>
+            </xsl:when>
+            <xsl:when test="$department">
+               <xsl:value-of select="$department"/>
+            </xsl:when>
+         </xsl:choose>
       </xr:Seller_contact_point>
    </xsl:template>
    <xsl:template mode="BT-42"
@@ -761,8 +764,7 @@
    <xsl:template mode="BG-9"
                  match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:DefinedTradeContact">
       <xsl:variable name="bg-contents" as="item()*"><!--Der Pfad /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:DefinedTradeContact der Instanz in konkreter Syntax wird auf 3 Objekte der EN 16931 abgebildet. -->
-         <xsl:apply-templates mode="BT-56" select="./ram:DepartmentName"/>
-         <xsl:apply-templates mode="BT-56" select="./ram:PersonName"/>
+         <xsl:apply-templates mode="BT-56" select="."/>
          <xsl:apply-templates mode="BT-57"
                               select="./ram:TelephoneUniversalCommunication/ram:CompleteNumber"/>
          <xsl:apply-templates mode="BT-58" select="./ram:EmailURIUniversalCommunication/ram:URIID"/>
@@ -776,11 +778,23 @@
       </xsl:if>
    </xsl:template>
    <xsl:template mode="BT-56"
-                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:DefinedTradeContact/ram:DepartmentName">
+                 match="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:DefinedTradeContact">
       <xr:Buyer_contact_point>
          <xsl:attribute name="xr:id" select="'BT-56'"/>
          <xsl:attribute name="xr:src" select="xr:src-path(.)"/>
-         <xsl:call-template name="text"/>
+         <xsl:variable name="department" select="ram:DepartmentName"/>
+         <xsl:variable name="person" select="ram:PersonName"/>
+         <xsl:choose>
+            <xsl:when test="$person and $department">
+               <xsl:value-of select="concat($person, ' (', $department, ')')"/>
+            </xsl:when>
+            <xsl:when test="$person">
+               <xsl:value-of select="$person"/>
+            </xsl:when>
+            <xsl:when test="$department">
+               <xsl:value-of select="$department"/>
+            </xsl:when>
+         </xsl:choose>
       </xr:Buyer_contact_point>
    </xsl:template>
    <xsl:template mode="BT-56"

--- a/src/xsl/l10n/de.xml
+++ b/src/xsl/l10n/de.xml
@@ -10,7 +10,7 @@
   <entry key="xr:Buyer_country_code" id="BT-55">Ländercode</entry>
   <entry key="xr:Buyer_identifier" id="BT-46">Kennung</entry>
   <entry key="xr:Buyer_identifier/@scheme_identifier" id="BT-46_scheme">Schema der Kennung</entry>
-  <entry key="xr:Buyer_contact_point" id="BT-56">Name</entry>
+  <entry key="xr:Buyer_contact_point" id="BT-56">Kontaktstelle</entry>
   <entry key="xr:Buyer_contact_telephone_number" id="BT-57">Telefon</entry>
   <entry key="xr:Buyer_contact_email_address" id="BT-58">E-Mail-Adresse</entry>
   <entry key="xr:Seller_name" id="BT-27">Firmenname</entry>
@@ -23,7 +23,7 @@
   <entry key="xr:Seller_country_code" id="BT-40">Ländercode</entry>
   <entry key="xr:Seller_identifier" id="BT-29">Kennung</entry>
   <entry key="xr:Seller_identifier/@scheme_identifier" id="BT-29_scheme">Schema der Kennung</entry>
-  <entry key="xr:Seller_contact_point" id="BT-41">Name</entry>
+  <entry key="xr:Seller_contact_point" id="BT-41">Kontaktstelle</entry>
   <entry key="xr:Seller_contact_telephone_number" id="BT-42">Telefon</entry>
   <entry key="xr:Seller_contact_email_address" id="BT-43">E-Mail-Adresse</entry>
   <entry key="xr:Invoice_number" id="BT-1">Rechnungsnummer</entry>


### PR DESCRIPTION
BT-41 (Seller_contact_point) and BT-56 (Buyer_contact_point) both map to DepartmentName AND PersonName of the respective "rsm:SupplyChainTradeTransaction/.../ram:DefinedTradeContact node.

This leads to two BT-41/BT-56 nodes in the XR file after transforming a CII containing both DepartmentName and PersonName. Both of these nodes are allowed only one time in XRechnung Version 3.0.2.

The xr-to-pdf.xsl file handles this by displaying every BT-41/BT-56 node, but these duplicates can lead to problems for people who are building their own software on top of this CII to XR transformation (e.g. when generating java objects from the XR or when building your own visualization).

I also suggest changing the german labels on the visualization from "Name" to "Kontaktstelle" as this better represents the meaning of this field.