### PR TITLE
Fix payment terms

### DIFF
--- a/src/xsl/xr-content.xsl
+++ b/src/xsl/xr-content.xsl
@@ -368,8 +368,44 @@
   <xsl:template name="uebersichtZahlungInfo_Content">
     <xsl:call-template name="list">
       <xsl:with-param name="content">        
-        <xsl:apply-templates mode="list-entry" select="xr:Payment_terms"/>        
-        <xsl:apply-templates mode="list-entry" select="xr:Payment_due_date"/>       
+        <!-- <xsl:apply-templates mode="list-entry" select="xr:Payment_terms"/> -->
+        <!-- <xsl:apply-templates mode="list-entry" select="xr:Payment_due_date"/> -->
+        <!--
+             We are going to tokenize the values of multiple elements that are related to each other. 
+             Therefore, we store a list of items into a variable per element.
+             This way, it is easy to correlate the items from all elements if necessary
+             and the tokenization is done only once per element.
+        -->
+        <xsl:variable name="terms">
+          <items>
+            <xsl:for-each select="tokenize(xr:Payment_terms,';')">
+              <item>
+                <xsl:value-of select="normalize-space(.)"/>
+              </item>
+            </xsl:for-each>
+          </items>
+        </xsl:variable>
+        <xsl:variable name="dates">
+          <items>
+            <xsl:for-each select="tokenize(xr:Payment_due_date,';')">
+              <item>
+                <xsl:value-of select="normalize-space(.)"/>
+              </item>
+            </xsl:for-each>
+          </items>
+        </xsl:variable>
+        <xsl:for-each select="$terms/items/item">
+          <xsl:variable name="termpos" select="position()"/>
+          <xsl:variable name="duedate" select="$dates/items/item[$termpos]"/>
+          <xsl:call-template name="list-entry-bt-7">
+            <xsl:with-param name="value" select="string(.)"/>
+            <xsl:with-param name="field-mapping-identifier" select="'xr:Payment_terms'"/>
+          </xsl:call-template>
+          <xsl:call-template name="list-entry-bt-7">
+            <xsl:with-param name="value" select="format-date(xs:date($duedate),xrf:_('date-format'))"/>
+            <xsl:with-param name="field-mapping-identifier" select="'xr:Payment_due_date'"/>
+          </xsl:call-template>
+        </xsl:for-each>
         <xsl:apply-templates mode="list-entry" select="xr:PAYMENT_INSTRUCTIONS/xr:Payment_means_type_code"/>
         <xsl:apply-templates mode="list-entry" select="xr:PAYMENT_INSTRUCTIONS/xr:Payment_means_text"/>
         <xsl:apply-templates mode="list-entry" select="xr:PAYMENT_INSTRUCTIONS/xr:Remittance_information"/>
@@ -821,7 +857,7 @@
             <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Specification_identifier">
               <xsl:with-param name="value" select="xrf:handle-specification-identifier(xr:PROCESS_CONTROL/xr:Specification_identifier)"></xsl:with-param>
             </xsl:apply-templates>
-            <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Business_process_type"/>
+            <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Business_process_type_identifier"/>
             <xsl:apply-templates mode="list-entry" select="xr:Invoiced_object_identifier"/>
             <xsl:apply-templates mode="list-entry" select="xr:Invoiced_object_identifier/@scheme_identifier">
               <xsl:with-param name="field-mapping-identifier" select="'xr:Invoiced_object_identifier/@scheme_identifier'"/>

--- a/src/xsl/xr-content.xsl
+++ b/src/xsl/xr-content.xsl
@@ -857,7 +857,7 @@
             <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Specification_identifier">
               <xsl:with-param name="value" select="xrf:handle-specification-identifier(xr:PROCESS_CONTROL/xr:Specification_identifier)"></xsl:with-param>
             </xsl:apply-templates>
-            <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Business_process_type_identifier"/>
+            <xsl:apply-templates mode="list-entry" select="xr:PROCESS_CONTROL/xr:Business_process_type"/>
             <xsl:apply-templates mode="list-entry" select="xr:Invoiced_object_identifier"/>
             <xsl:apply-templates mode="list-entry" select="xr:Invoiced_object_identifier/@scheme_identifier">
               <xsl:with-param name="field-mapping-identifier" select="'xr:Invoiced_object_identifier/@scheme_identifier'"/>


### PR DESCRIPTION
The current release of ZUGFeRD ([ZF232_EN.zip](https://www.ferd-net.de/fileadmin/user_upload/FeRD/Downloads/ZF232_EN.zip)) contains a test instance "Fremdwaehrung.xml":

- Examples/4. EXTENDED/EXTENDED_Fremdwaehrung/EXTENDED_Fremdwaehrung_factur-x.xml

This instance is valid according to the validation schema that is part of the release mentioned above:

- Schema/4. Factur-X_1.07.2_EXTENDED/_XSLT_EXTENDED/FACTUR-X_EXTENDED.xslt

The instance can be visualized as HTML by using the XSLT script [xrechnung-html.xsl](https://github.com/itplr-kosit/xrechnung-visualization/blob/master/src/xsl/xrechnung-html.xsl), but it cannot be visualized as PDF by using the XSLT script [xr-pdf.xsl](https://github.com/itplr-kosit/xrechnung-visualization/blob/master/src/xsl/xr-pdf.xsl).

> java -cp (...) net.sf.saxon.Transform -xsl:xr-pdf.xsl -s:Fremdwaehrung.xr -o:Fremdwaehrung.fo
> 
> Error at char 22 in expression in xsl:value-of/@select on line 197 column 159 of content-templates.xsl:
>   FORG0001  Invalid date "2024-12-01;2024-11-20" (Day must be two digits). Found while
>   atomizing the first argument of fn:normalize-space() in {$content} on line 128
> In template list on line 123 column 29 of content-templates.xsl:
>      invoked by xsl:call-template (tail calls omitted) at file:/(...)/xr-content.xsl#369
> In template uebersichtZahlungInfo on line 355 column 46 of xr-content.xsl:
>      invoked by xsl:call-template at file:/(...)/xr-content.xsl#31
> In template uebersicht_Content on line 22 column 43 of xr-content.xsl:
>      invoked by xsl:call-template at file:/(...)xr-content.xsl#17
> In template uebersicht on line 13 column 35 of xr-content.xsl:
>      invoked by xsl:call-template at file:/(...)/xr-pdf.xsl#85
>   In template rule with match="element(Q{urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung-1}invoice)" on line 59 of xr-pdf.xsl
>      invoked by built-in template rule (text-only)
> Invalid date "2024-12-01;2024-11-20" (Day must be two digits). Found while atomizing the first argument of fn:normalize-space() in {$content} on line 128

The reason is that the XSLT script [xrechnung-html.xsl](https://github.com/itplr-kosit/xrechnung-visualization/blob/master/src/xsl/xrechnung-html.xsl) already tokenizes the values of xr:Payment_terms and of xr:Payment_due_date, whereas the XSLT script [xr-pdf.xsl](https://github.com/itplr-kosit/xrechnung-visualization/blob/master/src/xsl/xr-pdf.xsl) does not do this yet.

I have fixed this by adding tokenization for the elements mentioned above. By applying the modified XSLT script a FO file can be generated successfully (and a PDF file can be generated by processing the FO file).

Note that this pull request does not contain my previous one ([PR#23](https://github.com/itplr-kosit/xrechnung-visualization/pull/23)). So, please, take care not to overwrite the previous one once merged.
