### PR TITLE
Fix line item discount

### DIFF
--- a/src/xsl/xr-content.xsl
+++ b/src/xsl/xr-content.xsl
@@ -559,7 +559,7 @@
           <xsl:with-param name="layout" select="'einspaltig'"/>
           <xsl:with-param name="content">
             <xsl:apply-templates mode="list-entry" select="xr:PRICE_DETAILS/xr:Item_price_discount">
-              <xsl:with-param name="value" select="format-number(xr:PRICE_DETAILS/xr:Item_price_discount,$at-least-two-picture,$lang)"/>
+              <xsl:with-param name="value" select="format-number(xr:PRICE_DETAILS/xr:Item_price_discount[1],$at-least-two-picture,$lang)"/>
             </xsl:apply-templates>
             <xsl:apply-templates mode="list-entry" select="xr:PRICE_DETAILS/xr:Item_gross_price">
               <xsl:with-param name="value" select="format-number(xr:PRICE_DETAILS/xr:Item_gross_price,$at-least-two-picture,$lang)"/>

--- a/src/xsl/xr-pdf/lib/structure/content-templates.xsl
+++ b/src/xsl/xr-pdf/lib/structure/content-templates.xsl
@@ -676,7 +676,7 @@
           <xsl:if test="xr:PRICE_DETAILS/xr:Item_price_discount">
             <xsl:value-of select="xrf:field-label('xr:Item_price_discount')"/>
             <xsl:text>: </xsl:text>
-            <xsl:value-of select="format-number(xr:PRICE_DETAILS/xr:Item_price_discount, $at-least-two-picture, $lang)"/>
+            <xsl:value-of select="format-number(xr:PRICE_DETAILS/xr:Item_price_discount[1], $at-least-two-picture, $lang)"/>
           </xsl:if>
         </xsl:with-param>
         <xsl:with-param name="col2">

--- a/src/xsl/xrechnung-html.xsl
+++ b/src/xsl/xrechnung-html.xsl
@@ -1310,7 +1310,7 @@
               </div>
               <div data-title="BT-147" class="BT-147 boxdaten wert">
                 <xsl:value-of
-                  select="xrf:format-with-at-least-two-digits(xr:PRICE_DETAILS/xr:Item_price_discount,$lang)" />
+                  select="xrf:format-with-at-least-two-digits(xr:PRICE_DETAILS/xr:Item_price_discount[1],$lang)" />
               </div>
             </div>
             <div class="boxzeile" role="listitem">


### PR DESCRIPTION
The current release of ZUGFeRD ([ZF232_EN.zip](https://www.ferd-net.de/fileadmin/user_upload/FeRD/Downloads/ZF232_EN.zip)) contains two test instances:

- Examples/4. EXTENDED/EXTENDED_Rechnungskorrektur/factur-x.xml
- Examples/4. EXTENDED/EXTENDED_Warenrechnung/factur-x.xml

Both instances are valid according to the validation schema that is part of the release mentioned above:

- Schema/4. Factur-X_1.07.2_EXTENDED/_XSLT_EXTENDED/FACTUR-X_EXTENDED.xslt

Unfortunately, both instances cannot be visualized as HTML and as PDF. An HTML file will be generated though, but it is incomplete.

> java -cp (...) net.sf.saxon.Transform -xsl:"xrechnung-html.xsl" -s:"Rechnungskorrektur.xr" -o:"Rechnungskorrektur.html"
> 
> Type error evaluating ($input-number) at char 41 in expression in xsl:when/@test on line 129 column 92 of functions.xsl:
>   XPTY0004  A sequence of more than one item is not allowed as the value in 'cast as'
>   expression (<xr:Item_price_discount>, <xr:Item_price_discount>)
> In function xrf:format-with-at-least-two-digits on line 124 column 75 of functions.xsl:
>      invoked by function call at file:/(...)/xrechnung-html.xsl#1313
>   In template rule with match="element(Q{urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung-1}INVOICE_LINE)" on line 1192 of xrechnung-html.xsl
>      invoked by xsl:apply-templates at file:/(...)/xrechnung-html.xsl#1187
> In template details on line 1182 column 32 of xrechnung-html.xsl:
>      invoked by xsl:call-template at file:/(...)/xrechnung-html.xsl#78
>   In template rule with match="/xr:invoice" on line 19 of xrechnung-html.xsl
>      invoked by built-in template rule (text-only)
> A sequence of more than one item is not allowed as the value in 'cast as' expression (<xr:Item_price_discount>, <xr:Item_price_discount>).

> java -cp (...) net.sf.saxon.Transform -xsl:"xr-pdf.xsl" -s:"Rechnungskorrektur.xr" -o:"Rechnungskorrektur.fo"
> 
> Error at char 31 in expression in xsl:with-param/@select on line 562 column 137 of xr-content.xsl:
>   XPTY0004  A sequence of more than one item is not allowed as the first argument of
>   fn:format-number() (0.03, 0.02) . Found while atomizing the first argument of
>   fn:normalize-space() in {$content} on line 128. Found while atomizing the first argument
>   of fn:normalize-space() in {$content} on line 23
> In template page on line 19 column 29 of content-templates.xsl:
>      invoked by xsl:call-template (tail calls omitted) at file:/(...)/xr-content.xsl#439
>   In template rule with match="element(Q{urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung-1}invoice)" on line 59 of xr-pdf.xsl
>      invoked by built-in template rule (text-only)
> A sequence of more than one item is not allowed as the first argument of fn:format-number() (0.03, 0.02).
> Found while atomizing the first argument of fn:normalize-space() in {$content} on line 128.
> Found while atomizing the first argument of fn:normalize-space() in {$content} on line 23.

According to the semantic model [xrechnung-semantic-model.xsd](https://github.com/itplr-kosit/xrechnung-visualization/blob/master/src/xsd/xrechnung-semantic-model.xsd) multiple discounts on the line-item level are not allowed.

So, the easiest fix is to retrieve the first item only. By applying the modified XSLT scripts both targets could be generated, HTML and FO.

Although I took the easiest fix, it should be considered whether the semantic model could/should be modified to allow for multiple discounts on the line-item level. In this case the fix would still work, but it won't be sufficient. Instead, we would need to iterate over multiple discounts on the line-item level.

Note that this pull request does not contain my previous ones ([PR#23](https://github.com/itplr-kosit/xrechnung-visualization/pull/23) and [PR#25](https://github.com/itplr-kosit/xrechnung-visualization/pull/25)). So, please, take care not to overwrite the previous ones once merged.

