### PR TITLE
BT-3 - Text for invoice type code

### DIFF
--- a/src/xsl/l10n/de.xml
+++ b/src/xsl/l10n/de.xml
@@ -256,4 +256,14 @@
   <entry key="_tax-code">St. Code</entry>
   <entry key="_total">Gesamt</entry>
   <entry key="_page">Seite</entry>
+  
+  <!-- BG 3 Additonal text for invoice type code -->
+  <entry key="xr:Invoice_type_code_text.326" id="BT-3">Teilrechnung</entry>
+  <entry key="xr:Invoice_type_code_text.380" id="BT-3">Rechnung</entry>
+  <entry key="xr:Invoice_type_code_text.384" id="BT-3">Rechnungskorrektur</entry>
+  <entry key="xr:Invoice_type_code_text.389" id="BT-3">Selbstfakturierte Rechnung</entry>
+  <entry key="xr:Invoice_type_code_text.381" id="BT-3">Gutschrift</entry>
+  <entry key="xr:Invoice_type_code_text.875" id="BT-3">Abschlagsrechnung</entry>
+  <entry key="xr:Invoice_type_code_text.876" id="BT-3">Teilschlussrechnung</entry>
+  <entry key="xr:Invoice_type_code_text.877" id="BT-3">Schlussrechnung</entry>
 </properties>

--- a/src/xsl/l10n/en.xml
+++ b/src/xsl/l10n/en.xml
@@ -254,4 +254,14 @@
   <entry key="_tax-code">Code</entry>
   <entry key="_total">Total</entry>
   <entry key="_page">Page</entry>
+
+  <!-- BG 3 Additonal text for invoice type code -->
+  <entry key="xr:Invoice_type_code_text.326" id="BT-3">Partial invoice</entry>
+  <entry key="xr:Invoice_type_code_text.380" id="BT-3">Commercial invoice</entry>
+  <entry key="xr:Invoice_type_code_text.384" id="BT-3">Corrected invoice</entry>
+  <entry key="xr:Invoice_type_code_text.389" id="BT-3">Self-billed invoice</entry>
+  <entry key="xr:Invoice_type_code_text.381" id="BT-3">Credit note</entry>
+  <entry key="xr:Invoice_type_code_text.875" id="BT-3">Partial construction invoice</entry>
+  <entry key="xr:Invoice_type_code_text.876" id="BT-3">Partial final construction invoice</entry>
+  <entry key="xr:Invoice_type_code_text.877" id="BT-3">Final construction invoice</entry>
 </properties>

--- a/src/xsl/xr-content.xsl
+++ b/src/xsl/xr-content.xsl
@@ -116,7 +116,7 @@
             else
             xr:Invoice_issue_date/text()"/>
         </xsl:apply-templates>
-        <xsl:apply-templates select="xr:Invoice_type_code" mode="list-entry"/>
+        <xsl:apply-templates select="xr:Invoice_type_code" mode="list-entry-bt-3"/>
         <xsl:apply-templates select="xr:Invoice_currency_code" mode="list-entry"/>
         <xsl:for-each select="tokenize(xr:Value_added_tax_point_date,';')">             
           <xsl:call-template name="list-entry-bt-7">

--- a/src/xsl/xr-pdf/lib/structure/content-templates.xsl
+++ b/src/xsl/xr-pdf/lib/structure/content-templates.xsl
@@ -205,6 +205,42 @@
       </fo:list-block>
     </xsl:if>
   </xsl:template>
+
+  <xsl:template match="@*|*" mode="list-entry-bt-3">
+    <xsl:param name="value"/>
+    <xsl:param name="field-mapping-identifier">
+      <xsl:value-of select="name()"/>
+    </xsl:param>
+    <xsl:if test="normalize-space(.)">
+      <xsl:variable name="field-mapping">
+        <xsl:call-template name="field-mapping">
+          <xsl:with-param name="identifier" select="$field-mapping-identifier"/>
+        </xsl:call-template>
+      </xsl:variable>
+      <fo:list-block margin-bottom="1mm"
+                     provisional-distance-between-starts="{$wert-legende-breite}mm">
+        <fo:list-item>
+          <fo:list-item-label end-indent="label-end()">
+            <fo:block xsl:use-attribute-sets="wert-legende"><xsl:value-of select="$field-mapping/label"/>:</fo:block>
+          </fo:list-item-label>
+          <fo:list-item-body start-indent="body-start()">
+            <fo:block xsl:use-attribute-sets="wert-ausgabe">
+              <xsl:variable name="key" select="concat('xr:Invoice_type_code_text.', .)"/>
+              <xsl:variable name="localized" select="xrf:_($key)"/>
+              <xsl:choose>
+                <xsl:when test="not(starts-with($localized, '???'))">
+                  <xsl:copy-of select="concat($localized, ' (', ., ')')"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="."/>
+                </xsl:otherwise>
+              </xsl:choose>
+             </fo:block>
+           </fo:list-item-body>
+        </fo:list-item>
+      </fo:list-block>
+    </xsl:if>
+  </xsl:template>
   
   <xsl:template name="list-entry-bt-7">
     <xsl:param name="value"/>

--- a/src/xsl/xrechnung-html.xsl
+++ b/src/xsl/xrechnung-html.xsl
@@ -442,7 +442,16 @@
                   <xsl:value-of select="xrf:_('xr:Invoice_type_code')" />:
                 </div>
                 <div data-title="BT-3" class="BT-3 boxdaten wert">
-                  <xsl:value-of select="xr:Invoice_type_code" />
+                  <xsl:variable name="key" select="concat('xr:Invoice_type_code_text.', xr:Invoice_type_code)"/>
+                  <xsl:variable name="localized" select="xrf:_($key)"/>
+                  <xsl:choose>
+                    <xsl:when test="$localized != $key">
+                      <xsl:copy-of select="concat($localized, ' (', xr:Invoice_type_code, ')')"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:value-of select="xr:Invoice_type_code"/>
+                    </xsl:otherwise>
+                  </xsl:choose>                
                 </div>
               </div>
               <div class="boxzeile" role="listitem">


### PR DESCRIPTION
In the visualization, invoice type codes are displayed numerically only. This pull request allows the text behind the code to be displayed as well.

“Commercial invoice (380)” is displayed if a translation could be found. If no translation is available for the code, only the code itself is displayed.